### PR TITLE
Add --debug flag for slog-based debug logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,12 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.25
     resource_class: large
     steps:
       - checkout
       - go/mod-download-cached
       - run:
          command: go install ./...
+      - run:
+         command: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # tor-fetcher
 
-Like curl, but for fetching .onion URLs that require "haproxy-protection"/"BasedFlare" PoW completion before access is granted.
+Like curl, but for fetching .onion URLs that require "haproxy-protection"/"BasedFlare"/Tartarus PoW completion before access is granted.
 
-Uses Golang's argon2 library instead of running the Javascript/WebAssembly bundle.
+Uses Golang's argon2 and sha256 libraries instead of running the Javascript/WebAssembly bundle.
+
+## Usage
+
+```
+tor-fetcher --target <url> [flags]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | (required) | The URL to retrieve |
+| `--proxy` | `socks5://127.0.0.1:9050` | SOCKS5 proxy address for Tor |
+| `--ua` | Firefox 140 on Windows | User-Agent string |
+| `--debug` | `false` | Enable debug logging to stderr |
+| `-p` | `1` | Argon2 parallelism |
+| `-l` | `32` | Argon2 key length |


### PR DESCRIPTION
## Summary
- Add `--debug` flag that enables structured debug logging via `log/slog` to stderr
- Uncomment all previously commented-out `log.Printf` debug lines and convert to `slog.Debug` calls with structured key-value pairs
- Without `--debug`, stdout contains only the response body (clean curl-like behavior)
- Bump CircleCI image from go 1.21 to 1.25 to match go.mod, and add `go test` step
- Update README with Tartarus support mention and usage/flags table

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [ ] Run without `--debug` and verify only response body on stdout
- [ ] Run with `--debug` and verify structured debug logs on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)