### PR TITLE
Skip TLS cert verification for onion fetches

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,9 @@ func NewTorClient() *TorClient {
 			return nil, err
 		}
 		// TLS handshake with Firefox fingerprint.
-		cfg := &utls.Config{ServerName: host}
+		// Skip verification: onion services authenticate via the .onion
+		// address itself, so the server cert is cosmetic and often expired.
+		cfg := &utls.Config{ServerName: host, InsecureSkipVerify: true}
 		uConn := utls.UClient(rawConn, cfg, utls.HelloFirefox_Auto)
 		if err := uConn.HandshakeContext(ctx); err != nil {
 			rawConn.Close()


### PR DESCRIPTION
## Summary
- Onion services authenticate via the .onion address itself, making the server TLS cert cosmetic
- Current outage: onion cert expired at 2026-05-10T07:05:46Z, breaking all fetches
- `InsecureSkipVerify: true` keeps the fetcher working across cert renewals

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [ ] Redeploy and confirm fetches recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)