### PR TITLE
Re-fetch target with caller's method after Tartarus clearance

### DIFF
--- a/main.go
+++ b/main.go
@@ -386,7 +386,7 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 
 		if strings.Contains(body, "data-ttrs-challenge") {
 			tracef("  -> Tartarus challenge")
-			challengeResp, err := tc.solveTartarus(requestURL, body)
+			challengeResp, err := tc.solveTartarus(method, requestURL, body)
 			if err != nil {
 				return nil, err
 			}
@@ -417,7 +417,7 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 	return nil, fmt.Errorf("too many redirects/challenges")
 }
 
-func (tc *TorClient) solveTartarus(requestURL *url.URL, body string) (*http.Response, error) {
+func (tc *TorClient) solveTartarus(method string, requestURL *url.URL, body string) (*http.Response, error) {
 	salt := extractAttr(body, "data-ttrs-challenge")
 	diffStr := extractAttr(body, "data-ttrs-difficulty")
 	difficulty, err := strconv.Atoi(diffStr)
@@ -467,8 +467,12 @@ func (tc *TorClient) solveTartarus(requestURL *url.URL, body string) (*http.Resp
 		slog.Debug("tartarus jar cookies", "url", requestURL, "cookies", tc.c.Jar.Cookies(requestURL))
 	}
 
-	// Re-GET the original target (cookie jar preserves ttrs_clearance).
-	return tc.Get(requestURL.String(), requestURL.String())
+	// Re-fetch the original target with the CALLER'S method now that the
+	// ttrs_clearance cookie is set (the jar preserves it). Using the caller's
+	// method rather than a hardcoded GET means a HEAD probe never downloads the
+	// destination body — essential when the caller must learn a resource's
+	// status without fetching the resource itself. For GET this is unchanged.
+	return tc.do(method, requestURL.String(), requestURL.String())
 }
 
 func (tc *TorClient) solveBasedFlare(requestURL *url.URL, body string) (*http.Response, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -277,8 +277,18 @@ func TestFetchHEADThroughTartarus(t *testing.T) {
 	if !solvedWithGET {
 		t.Error("challenge body was never fetched with GET")
 	}
-	if len(clearedMethods) == 0 || clearedMethods[len(clearedMethods)-1] != "HEAD" {
-		t.Errorf("destination methods = %v, want final request to be HEAD", clearedMethods)
+	// Safety property: once clearance is established, the destination must be
+	// reached ONLY via HEAD. A single GET here would download the resource
+	// body — exactly what a HEAD probe exists to avoid (e.g. probing a path
+	// the caller must not fetch). So assert NO cleared request used GET, not
+	// merely that the last one was HEAD.
+	if len(clearedMethods) == 0 {
+		t.Error("destination was never reached after clearance")
+	}
+	for _, m := range clearedMethods {
+		if m != "HEAD" {
+			t.Errorf("cleared destination reached with %q; a HEAD probe must never fetch the body (methods = %v)", m, clearedMethods)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`-method HEAD` (added in #39) does not actually keep a HEAD probe body-less when the target is behind Tartarus.

`solveTartarus` ended with a hardcoded `tc.Get(...)` to re-fetch the destination once the `ttrs_clearance` cookie was set, and `Fetch` then re-issued the request via `finalize` with the caller's method. So the sequence for a HEAD probe was:

1. `HEAD` target → 203 challenge
2. `GET` target → challenge HTML (needed to read the PoW params)
3. `POST /.ttrs/challenge` → clearance cookie
4. **`GET` target (cleared) → 200 + full body** ← `solveTartarus`'s `tc.Get`
5. `HEAD` target (cleared) → 200, no body ← `finalize`

Step 4 downloads the entire destination body before the HEAD ever runs — defeating the purpose of HEAD when the caller must learn a resource's status *without* fetching the resource itself.

## Fix

Thread the caller's method into `solveTartarus` and use `tc.do(method, ...)` for the post-clearance re-fetch.

- **GET is unchanged** (`tc.do("GET", ...)` == `tc.Get`).
- **HEAD now transfers no destination body at any point.** The challenge HTML is still read with `GET` (a HEAD can't see a body), which is correct — that response is the challenge page, never the destination.

## Test

`TestFetchHEADThroughTartarus` previously only checked that the *last* cleared request was HEAD, so it passed even with the body-downloading GET (`clearedMethods = [GET HEAD]`). Strengthened to assert **no** cleared-destination request uses GET.

Verified red-green: with the old `tc.Get` line the test fails with `cleared destination reached with "GET" ... methods = [GET HEAD]`; with the fix it's `[HEAD]`. Full suite passes; `gofmt`/`go vet` clean.