### PR TITLE
Refuse 403 challenges for HEAD requests instead of falling back to GET

### DIFF
--- a/main.go
+++ b/main.go
@@ -365,6 +365,20 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 			return resp, nil
 		}
 
+		// Body-safety for HEAD probes. Only a 203 Tartarus interstitial is safe
+		// to resolve in HEAD mode: Tartarus consistently gates every unsolved
+		// request, so the challenge-reading GET below returns the challenge
+		// page, never the resource. A 403 is different — it is intermittent and
+		// indistinguishable from a genuine Forbidden, and resolving it means
+		// GETing the target to read a "challenge" body that may actually BE the
+		// resource (downloading it). A HEAD probe exists precisely to avoid
+		// fetching the body, so refuse a 403 outright rather than fall back to a
+		// GET of the target. The caller can retry for a clean Tartarus-only pass.
+		if method == "HEAD" && resp.StatusCode == http.StatusForbidden {
+			resp.Body.Close()
+			return nil, fmt.Errorf("refusing to resolve a 403 challenge for a HEAD request: it would require a GET of the target that could download the body; retry for a Tartarus-only pass")
+		}
+
 		// Read the challenge body. HEAD and other bodyless methods can't see
 		// it, so refetch the challenge page with GET.
 		chResp := resp

--- a/main_test.go
+++ b/main_test.go
@@ -292,6 +292,37 @@ func TestFetchHEADThroughTartarus(t *testing.T) {
 	}
 }
 
+func TestFetchHEADRefusesForbidden(t *testing.T) {
+	// A HEAD that draws a 403 must NOT fall back to a GET of the target: that
+	// GET can return the resource body (a 403 is intermittent / indistinguish-
+	// able from a real Forbidden, and the "challenge" body may actually be the
+	// file). So Fetch must error out without ever GETing the target.
+	var sawGET bool
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" && r.Method == "GET" {
+			// If the guard were missing, the fallback GET would land here and
+			// the body would be downloaded. The resource leaks on GET.
+			sawGET = true
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "RESOURCE BODY THAT MUST NOT BE FETCHED")
+			return
+		}
+		// HEAD (and anything else) → 403.
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+	defer setMethod("HEAD")()
+
+	tc := newTestClient(ts)
+	_, err := tc.Fetch(ts.URL+"/", "")
+	if err == nil {
+		t.Fatal("expected an error refusing the 403 challenge in HEAD mode, got nil")
+	}
+	if sawGET {
+		t.Error("a GET reached the target after a 403 HEAD — must never fall back to a body-fetching GET")
+	}
+}
+
 func TestArgonCheck(t *testing.T) {
 	// Use minimal parameters so the test runs quickly.
 	p := ArgonParams{


### PR DESCRIPTION
## Problem

A `HEAD` that draws a **403** falls back to a **GET of the target** to read the "challenge" body (a HEAD can't see a body). But that GET can return the **actual resource**:

- A 403 on this host is **intermittent** and **indistinguishable from a genuine Forbidden**.
- The "challenge" body the fallback GET reads may simply **be the file**. The detector then mislabels it (it only checks for the *absence* of the `data-ttrs-challenge` marker, so any non-Tartarus body — including a binary file — is called "BasedFlare").

**Observed live:** a HEAD probe drew a stray 403, the fallback GET **downloaded the full 64 KB file**, and it was mislabeled as a BasedFlare challenge. That defeats the entire purpose of a HEAD probe — learning status *without* downloading the body. Diagnostic over 16 fetches: GET returned the file 8/8 (never a challenge page), HEAD went Tartarus-only 8/8 — confirming the "BasedFlare" sighting was the fallback GET returning the file, not a real second challenge.

## Fix

Only a **203 Tartarus** interstitial is safe to resolve in HEAD mode: Tartarus consistently gates *every* unsolved request, so the challenge-reading GET returns the challenge page, never the resource. So in HEAD mode, **refuse a 403 outright** (close + error) before any fallback GET. Callers retry for a clean Tartarus-only pass.

- 203 → solve Tartarus → re-HEAD (unchanged, body-safe).
- 200 / 404 → returned from the HEAD directly (no body).
- 403 → error, no GET/POST of the target ever happens.
- **GET behavior is unchanged.**

## Test

`TestFetchHEADRefusesForbidden`: a 403 on HEAD must make `Fetch` error **without ever issuing a GET to the target**. Verified red-green — without the guard the fallback GET fires and the body is downloaded (`got nil` error); with it, `Fetch` errors and the target is never GETed. Full suite + `gofmt`/`go vet` clean.

## Note

Builds on #40. Together: #40 makes the Tartarus clearance re-fetch honor the caller's method; this PR ensures a HEAD never silently degrades into a body-downloading GET on a 403.