### PR TITLE
Support POSTing forms (--data, --cookie/--cookie-jar) and a Tartarus API-style challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,23 @@ tor-fetcher --target <url> [flags]
 | `-l` | `32` | Argon2 key length |
 | `--method` / `-X` | `GET` | HTTP request method, e.g. `POST` |
 | `--data` / `-d` | (none) | `application/x-www-form-urlencoded` POST body, e.g. `"foo=bar&baz=qux"` |
+| `--cookie` / `-b` | (none) | Read cookies for `--target`'s host from this JSON file before fetching |
+| `--cookie-jar` / `-c` | (none) | Write cookies for `--target`'s host to this JSON file after fetching |
 | `--trace` | `false` | Print the request/redirect/challenge chain to stderr |
+
+### Submitting a form that needs a session (e.g. a XenForo search)
+
+A form POST that requires a matching CSRF token generally also requires the
+session cookie it was issued under — a token scraped from an unrelated page
+load won't validate. Establish the session first, then reuse it:
+
+```
+# 1. GET a page to start a session and read its CSRF token from the HTML.
+tor-fetcher --target https://forum.onion/ --cookie-jar session.json > page.html
+token=$(grep -o '_xfToken" value="[^"]*"' page.html | cut -d'"' -f3)
+
+# 2. POST the form using the SAME session.
+tor-fetcher -X POST --cookie session.json \
+  --data "keywords=example&c[users]=someuser&order=date&_xfToken=${token}" \
+  --target https://forum.onion/search/search
+```

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ tor-fetcher --target <url> [flags]
 | `--debug` | `false` | Enable debug logging to stderr |
 | `-p` | `1` | Argon2 parallelism |
 | `-l` | `32` | Argon2 key length |
+| `--method` / `-X` | `GET` | HTTP request method, e.g. `POST` |
+| `--data` / `-d` | (none) | `application/x-www-form-urlencoded` POST body, e.g. `"foo=bar&baz=qux"` |
+| `--trace` | `false` | Print the request/redirect/challenge chain to stderr |

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -35,12 +36,18 @@ var debug = flag.Bool("debug", false, "Enable debug logging")
 var method = flag.String("method", "GET", "HTTP request method, e.g. HEAD")
 var trace = flag.Bool("trace", false, "Print the request/redirect/challenge chain to stderr")
 var postData = flag.String("data", "", "application/x-www-form-urlencoded POST body, e.g. \"foo=bar&baz=qux\"")
+var cookieIn = flag.String("cookie", "", "Read cookies for --target's host from this JSON file before fetching (see --cookie-jar)")
+var cookieOut = flag.String("cookie-jar", "", "Write cookies for --target's host to this JSON file after fetching")
 
 func init() {
 	// Curl-style alias for --method.
 	flag.StringVar(method, "X", "GET", "alias for --method")
 	// Curl-style alias for --data.
 	flag.StringVar(postData, "d", "", "alias for --data")
+	// Curl-style alias for --cookie.
+	flag.StringVar(cookieIn, "b", "", "alias for --cookie")
+	// Curl-style alias for --cookie-jar.
+	flag.StringVar(cookieOut, "c", "", "alias for --cookie-jar")
 }
 
 // tracef prints a line to stderr describing a step in the fetch chain when
@@ -61,12 +68,27 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+	targetURL, err := url.Parse(*target)
+	if err != nil {
+		log.Fatalf("parsing --target: %v", err)
+	}
+
 	tc := NewTorClient()
+	if *cookieIn != "" {
+		if err := loadCookies(*cookieIn, tc.c.Jar, targetURL); err != nil {
+			log.Fatalf("loading --cookie: %v", err)
+		}
+	}
 	resp, err := tc.Fetch(*target, "", []byte(*postData))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer resp.Body.Close()
+	if *cookieOut != "" {
+		if err := saveCookies(*cookieOut, tc.c.Jar, resp.Request.URL); err != nil {
+			log.Fatalf("saving --cookie-jar: %v", err)
+		}
+	}
 
 	// Surface the status line and headers on stderr for non-200 responses
 	// (and HEAD, which has no body) so failures and probes are debuggable.
@@ -86,6 +108,47 @@ func main() {
 	if resp.StatusCode != http.StatusOK {
 		os.Exit(1)
 	}
+}
+
+// jsonCookie is the on-disk shape used by --cookie/--cookie-jar. It carries
+// just enough of http.Cookie to round-trip a session between separate
+// tor-fetcher invocations (e.g. fetch a page to establish a session and CSRF
+// token, then POST a form using that same session).
+type jsonCookie struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// loadCookies reads cookies from path and installs them into jar for u's
+// origin, so a subsequent Fetch(u, ...) reuses the session.
+func loadCookies(path string, jar http.CookieJar, u *url.URL) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var cookies []jsonCookie
+	if err := json.Unmarshal(data, &cookies); err != nil {
+		return err
+	}
+	httpCookies := make([]*http.Cookie, 0, len(cookies))
+	for _, c := range cookies {
+		httpCookies = append(httpCookies, &http.Cookie{Name: c.Name, Value: c.Value})
+	}
+	jar.SetCookies(u, httpCookies)
+	return nil
+}
+
+// saveCookies writes jar's cookies for u's origin to path as JSON.
+func saveCookies(path string, jar http.CookieJar, u *url.URL) error {
+	var cookies []jsonCookie
+	for _, c := range jar.Cookies(u) {
+		cookies = append(cookies, jsonCookie{Name: c.Name, Value: c.Value})
+	}
+	data, err := json.MarshalIndent(cookies, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
 }
 
 // decodeBody reads a response body, transparently decompressing gzip.

--- a/main.go
+++ b/main.go
@@ -160,6 +160,31 @@ func extractAttr(s, attr string) string {
 	return s[start : start+end]
 }
 
+// tartarusChallengeURL reports the URL to GET for a Tartarus challenge's
+// salt/difficulty when resp signals an API-style challenge via a 401 with a
+// `Www-Authenticate: Tartarus ... challenge_url="..."` header — the shape
+// used by XHR/form endpoints (e.g. a search POST), as opposed to the classic
+// 203/403 page interstitial where the target itself IS the challenge page.
+// Returns nil when resp isn't this kind of challenge.
+func tartarusChallengeURL(resp *http.Response) *url.URL {
+	if resp.StatusCode != http.StatusUnauthorized {
+		return nil
+	}
+	auth := resp.Header.Get("Www-Authenticate")
+	if !strings.HasPrefix(auth, "Tartarus ") {
+		return nil
+	}
+	loc := extractAttr(auth, "challenge_url")
+	if loc == "" {
+		return nil
+	}
+	resolved, err := resp.Request.URL.Parse(loc)
+	if err != nil {
+		return nil
+	}
+	return resolved
+}
+
 type TorClient struct {
 	c http.Client
 }
@@ -373,7 +398,8 @@ func (tc *TorClient) Fetch(target, referer string, reqBody []byte) (*http.Respon
 		}
 
 		// Not a challenge — return directly (with the caller's method).
-		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNonAuthoritativeInfo {
+		challengeURL := tartarusChallengeURL(resp)
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNonAuthoritativeInfo && challengeURL == nil {
 			return resp, nil
 		}
 
@@ -386,21 +412,34 @@ func (tc *TorClient) Fetch(target, referer string, reqBody []byte) (*http.Respon
 		// resource (downloading it). A HEAD probe exists precisely to avoid
 		// fetching the body, so refuse a 403 outright rather than fall back to a
 		// GET of the target. The caller can retry for a clean Tartarus-only pass.
+		// (The 401 API-style challenge below is always safe: its GET target is
+		// the dedicated /.ttrs/challenge endpoint, never the destination
+		// resource, so there's nothing to leak.)
 		if method == "HEAD" && resp.StatusCode == http.StatusForbidden {
 			resp.Body.Close()
 			return nil, fmt.Errorf("refusing to resolve a 403 challenge for a HEAD request: it would require a GET of the target that could download the body; retry for a Tartarus-only pass")
 		}
 
-		// Read the challenge body. HEAD and other bodyless methods can't see
-		// it, so refetch the challenge page with GET.
+		// The original target URL to retry once clearance is established.
+		// Captured before chResp may point at a different challenge endpoint.
+		requestURL := resp.Request.URL
+
+		// Read the challenge body. Bodyless methods can't see it, and an
+		// API-style 401 challenge carries the salt/difficulty on a separate
+		// endpoint, not the response we already have — refetch with GET
+		// whenever the challenge body isn't already what we're holding.
+		fetchURL := currentURL
+		if challengeURL != nil {
+			fetchURL = challengeURL.String()
+		}
 		chResp := resp
-		if method != "GET" {
+		if method != "GET" || fetchURL != currentURL {
 			resp.Body.Close()
-			chResp, err = tc.do("GET", currentURL, currentReferer, nil)
+			chResp, err = tc.do("GET", fetchURL, currentReferer, nil)
 			if err != nil {
 				return nil, err
 			}
-			tracef("GET %s -> %d %s (challenge body)", currentURL, chResp.StatusCode, http.StatusText(chResp.StatusCode))
+			tracef("GET %s -> %d %s (challenge body)", fetchURL, chResp.StatusCode, http.StatusText(chResp.StatusCode))
 		}
 		bodyBytes, err := io.ReadAll(chResp.Body)
 		chResp.Body.Close()
@@ -408,7 +447,6 @@ func (tc *TorClient) Fetch(target, referer string, reqBody []byte) (*http.Respon
 			return nil, err
 		}
 		body := string(bodyBytes)
-		requestURL := chResp.Request.URL
 
 		if strings.Contains(body, "data-ttrs-challenge") {
 			tracef("  -> Tartarus challenge")

--- a/main.go
+++ b/main.go
@@ -34,10 +34,13 @@ var socksAddr = flag.String("proxy", "socks5://127.0.0.1:9050", "SOCKS5 proxy ad
 var debug = flag.Bool("debug", false, "Enable debug logging")
 var method = flag.String("method", "GET", "HTTP request method, e.g. HEAD")
 var trace = flag.Bool("trace", false, "Print the request/redirect/challenge chain to stderr")
+var postData = flag.String("data", "", "application/x-www-form-urlencoded POST body, e.g. \"foo=bar&baz=qux\"")
 
 func init() {
 	// Curl-style alias for --method.
 	flag.StringVar(method, "X", "GET", "alias for --method")
+	// Curl-style alias for --data.
+	flag.StringVar(postData, "d", "", "alias for --data")
 }
 
 // tracef prints a line to stderr describing a step in the fetch chain when
@@ -59,7 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 	tc := NewTorClient()
-	resp, err := tc.Fetch(*target, "")
+	resp, err := tc.Fetch(*target, "", []byte(*postData))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -172,18 +175,27 @@ func setHeaders(req *http.Request, referer string) {
 	req.Header.Set("Upgrade-Insecure-Requests", "1")
 }
 
-// do issues a bodyless request with the given method (GET, HEAD, ...).
-func (tc *TorClient) do(method, target, referer string) (*http.Response, error) {
-	req, err := http.NewRequest(method, target, nil)
+// do issues a request with the given method (GET, HEAD, POST, ...). reqBody
+// is nil for bodyless requests; when non-empty it is sent as an
+// application/x-www-form-urlencoded body (e.g. for -X POST -d "...").
+func (tc *TorClient) do(method, target, referer string, reqBody []byte) (*http.Response, error) {
+	var bodyReader io.Reader
+	if len(reqBody) > 0 {
+		bodyReader = strings.NewReader(string(reqBody))
+	}
+	req, err := http.NewRequest(method, target, bodyReader)
 	if err != nil {
 		return nil, err
 	}
 	setHeaders(req, referer)
+	if len(reqBody) > 0 {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
 	return tc.c.Do(req)
 }
 
 func (tc *TorClient) Get(target, referer string) (*http.Response, error) {
-	return tc.do("GET", target, referer)
+	return tc.do("GET", target, referer, nil)
 }
 
 func (tc *TorClient) PostForm(target, referer string, data url.Values) (*http.Response, error) {
@@ -315,7 +327,7 @@ func NewTorClient() *TorClient {
 	return &TorClient{c: httpClient}
 }
 
-func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
+func (tc *TorClient) Fetch(target, referer string, reqBody []byte) (*http.Response, error) {
 	method := strings.ToUpper(*method)
 	if method == "" {
 		method = "GET"
@@ -325,8 +337,8 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 
 	// Challenges are always solved with GET (we need the HTML body and a
 	// clearance cookie). finalize re-issues the destination request with the
-	// caller's method once clearance is established. For plain GET it is a
-	// no-op, so there is no extra round trip in the common case.
+	// caller's method (and body) once clearance is established. For plain
+	// GET it is a no-op, so there is no extra round trip in the common case.
 	finalize := func(resp *http.Response) (*http.Response, error) {
 		if method == "GET" {
 			return resp, nil
@@ -335,11 +347,11 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 		ref := resp.Request.Header.Get("Referer")
 		resp.Body.Close()
 		tracef("%s %s (after clearance)", method, u)
-		return tc.do(method, u, ref)
+		return tc.do(method, u, ref, reqBody)
 	}
 
 	for range 10 { // max redirect/challenge hops
-		resp, err := tc.do(method, currentURL, currentReferer)
+		resp, err := tc.do(method, currentURL, currentReferer, reqBody)
 		if err != nil {
 			return nil, err
 		}
@@ -384,7 +396,7 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 		chResp := resp
 		if method != "GET" {
 			resp.Body.Close()
-			chResp, err = tc.do("GET", currentURL, currentReferer)
+			chResp, err = tc.do("GET", currentURL, currentReferer, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -400,7 +412,7 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 
 		if strings.Contains(body, "data-ttrs-challenge") {
 			tracef("  -> Tartarus challenge")
-			challengeResp, err := tc.solveTartarus(method, requestURL, body)
+			challengeResp, err := tc.solveTartarus(method, requestURL, body, reqBody)
 			if err != nil {
 				return nil, err
 			}
@@ -431,7 +443,7 @@ func (tc *TorClient) Fetch(target, referer string) (*http.Response, error) {
 	return nil, fmt.Errorf("too many redirects/challenges")
 }
 
-func (tc *TorClient) solveTartarus(method string, requestURL *url.URL, body string) (*http.Response, error) {
+func (tc *TorClient) solveTartarus(method string, requestURL *url.URL, body string, reqBody []byte) (*http.Response, error) {
 	salt := extractAttr(body, "data-ttrs-challenge")
 	diffStr := extractAttr(body, "data-ttrs-difficulty")
 	difficulty, err := strconv.Atoi(diffStr)
@@ -481,12 +493,13 @@ func (tc *TorClient) solveTartarus(method string, requestURL *url.URL, body stri
 		slog.Debug("tartarus jar cookies", "url", requestURL, "cookies", tc.c.Jar.Cookies(requestURL))
 	}
 
-	// Re-fetch the original target with the CALLER'S method now that the
-	// ttrs_clearance cookie is set (the jar preserves it). Using the caller's
-	// method rather than a hardcoded GET means a HEAD probe never downloads the
-	// destination body — essential when the caller must learn a resource's
-	// status without fetching the resource itself. For GET this is unchanged.
-	return tc.do(method, requestURL.String(), requestURL.String())
+	// Re-fetch the original target with the CALLER'S method and body now that
+	// the ttrs_clearance cookie is set (the jar preserves it). Using the
+	// caller's method rather than a hardcoded GET means a HEAD probe never
+	// downloads the destination body — essential when the caller must learn a
+	// resource's status without fetching the resource itself. For GET this is
+	// unchanged.
+	return tc.do(method, requestURL.String(), requestURL.String(), reqBody)
 }
 
 func (tc *TorClient) solveBasedFlare(requestURL *url.URL, body string) (*http.Response, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"testing"
 )
@@ -56,6 +57,46 @@ func TestExtractAttr(t *testing.T) {
 					tt.html, tt.attr, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSaveLoadCookiesRoundTrip(t *testing.T) {
+	// --cookie-jar / --cookie let a later invocation reuse a session (e.g.
+	// established by a plain GET) for a POST that needs a matching CSRF
+	// token + session cookie. Verify the round trip preserves name/value.
+	u, err := url.Parse("https://example.onion/")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+
+	saveJar, _ := cookiejar.New(nil)
+	saveJar.SetCookies(u, []*http.Cookie{
+		{Name: "xf_session", Value: "abc123"},
+		{Name: "ttrs_clearance", Value: "def456"},
+	})
+
+	path := filepath.Join(t.TempDir(), "cookies.json")
+	if err := saveCookies(path, saveJar, u); err != nil {
+		t.Fatalf("saveCookies: %v", err)
+	}
+
+	loadJar, _ := cookiejar.New(nil)
+	if err := loadCookies(path, loadJar, u); err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, c := range loadJar.Cookies(u) {
+		got[c.Name] = c.Value
+	}
+	want := map[string]string{"xf_session": "abc123", "ttrs_clearance": "def456"}
+	for name, wantVal := range want {
+		if got[name] != wantVal {
+			t.Errorf("cookie %q = %q, want %q", name, got[name], wantVal)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("loaded %d cookies, want %d (%v)", len(got), len(want), got)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -106,7 +106,7 @@ func TestSolveTartarusFlow(t *testing.T) {
 	testClient := ts.Client()
 	testClient.Jar = jar
 	tc := &TorClient{c: *testClient}
-	resp, err := tc.Fetch(ts.URL+"/", "")
+	resp, err := tc.Fetch(ts.URL+"/", "", nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestFetchMethodHEAD(t *testing.T) {
 	defer setMethod("HEAD")()
 
 	tc := newTestClient(ts)
-	resp, err := tc.Fetch(ts.URL+"/", "")
+	resp, err := tc.Fetch(ts.URL+"/", "", nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestFetchReturnsNonOKBody(t *testing.T) {
 	defer setMethod("GET")()
 
 	tc := newTestClient(ts)
-	resp, err := tc.Fetch(ts.URL+"/", "")
+	resp, err := tc.Fetch(ts.URL+"/", "", nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestFetchHEADThroughTartarus(t *testing.T) {
 	defer setMethod("HEAD")()
 
 	tc := newTestClient(ts)
-	resp, err := tc.Fetch(ts.URL+"/", "")
+	resp, err := tc.Fetch(ts.URL+"/", "", nil)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -292,6 +292,71 @@ func TestFetchHEADThroughTartarus(t *testing.T) {
 	}
 }
 
+func TestFetchPOSTThroughTartarus(t *testing.T) {
+	// A POST body (e.g. a search form submission) must survive a Tartarus
+	// challenge round trip: the challenge itself is solved with a bodyless
+	// GET, but the destination request re-issued after clearance must carry
+	// the original POST body and its form Content-Type.
+	const (
+		wantSalt = "a92a106fa4e8c2398ebcabecefebf28c_69853ed8"
+		wantDiff = "16"
+		wantBody = "keywords=example&c%5Busers%5D=someuser"
+	)
+	challengeHTML := fmt.Sprintf(
+		`<html data-ttrs-challenge="%s" data-ttrs-difficulty="%s"></html>`,
+		wantSalt, wantDiff)
+
+	var gotBody, gotContentType string
+	var gotMethod string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/.ttrs/challenge" && r.Method == "POST":
+			http.SetCookie(w, &http.Cookie{Name: "ttrs_clearance", Value: "test", Path: "/"})
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"success":true}`)
+		case r.URL.Path == "/search/search":
+			if _, err := r.Cookie("ttrs_clearance"); err != nil {
+				// Not yet cleared: serve the challenge (bodyless probe is fine
+				// here, only GET can read this body per the existing flow).
+				w.WriteHeader(http.StatusNonAuthoritativeInfo)
+				fmt.Fprint(w, challengeHTML)
+				return
+			}
+			// Cleared: record what reached the destination.
+			gotMethod = r.Method
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+			gotContentType = r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "<html>results</html>")
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+	defer setMethod("POST")()
+
+	tc := newTestClient(ts)
+	resp, err := tc.Fetch(ts.URL+"/search/search", "", []byte(wantBody))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("destination reached with method %q, want POST", gotMethod)
+	}
+	if gotBody != wantBody {
+		t.Errorf("destination body = %q, want %q", gotBody, wantBody)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("destination Content-Type = %q, want application/x-www-form-urlencoded", gotContentType)
+	}
+}
+
 func TestFetchHEADRefusesForbidden(t *testing.T) {
 	// A HEAD that draws a 403 must NOT fall back to a GET of the target: that
 	// GET can return the resource body (a 403 is intermittent / indistinguish-
@@ -314,7 +379,7 @@ func TestFetchHEADRefusesForbidden(t *testing.T) {
 	defer setMethod("HEAD")()
 
 	tc := newTestClient(ts)
-	_, err := tc.Fetch(ts.URL+"/", "")
+	_, err := tc.Fetch(ts.URL+"/", "", nil)
 	if err == nil {
 		t.Fatal("expected an error refusing the 403 challenge in HEAD mode, got nil")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -357,6 +357,81 @@ func TestFetchPOSTThroughTartarus(t *testing.T) {
 	}
 }
 
+func TestFetchPOSTThroughAPIStyleTartarusChallenge(t *testing.T) {
+	// Some endpoints (observed live against a XenForo /search/search POST)
+	// answer an unsolved request with 401 + a Www-Authenticate header
+	// pointing at a separate challenge_url, instead of serving the classic
+	// 203/HTML interstitial on the target itself. The salt/difficulty must
+	// be read from that separate URL, and the retry after clearance must
+	// still hit the ORIGINAL target (with its original method/body), not
+	// the challenge endpoint.
+	const (
+		wantSalt = "a92a106fa4e8c2398ebcabecefebf28c_69853ed8"
+		wantDiff = "16"
+		wantBody = "keywords=example&c%5Busers%5D=someuser"
+	)
+	challengeHTML := fmt.Sprintf(
+		`<html data-ttrs-challenge="%s" data-ttrs-difficulty="%s"></html>`,
+		wantSalt, wantDiff)
+
+	var gotChallengeURLMethod string
+	var gotBody, gotContentType string
+	var gotDestMethod string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/.ttrs/challenge" && r.Method == "GET":
+			gotChallengeURLMethod = r.Method
+			w.WriteHeader(http.StatusNonAuthoritativeInfo)
+			fmt.Fprint(w, challengeHTML)
+		case r.URL.Path == "/.ttrs/challenge" && r.Method == "POST":
+			http.SetCookie(w, &http.Cookie{Name: "ttrs_clearance", Value: "test", Path: "/"})
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"success":true}`)
+		case r.URL.Path == "/search/search":
+			if _, err := r.Cookie("ttrs_clearance"); err != nil {
+				w.Header().Set("Www-Authenticate", `Tartarus realm="challenge", challenge_url="/.ttrs/challenge"`)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"error":"challenge_required","challenge_url":"/.ttrs/challenge"}`)
+				return
+			}
+			gotDestMethod = r.Method
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+			gotContentType = r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "<html>results</html>")
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+	defer setMethod("POST")()
+
+	tc := newTestClient(ts)
+	resp, err := tc.Fetch(ts.URL+"/search/search", "", []byte(wantBody))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if gotChallengeURLMethod != "GET" {
+		t.Error("challenge_url was never GET'd to read the salt/difficulty")
+	}
+	if gotDestMethod != "POST" {
+		t.Errorf("destination reached with method %q, want POST", gotDestMethod)
+	}
+	if gotBody != wantBody {
+		t.Errorf("destination body = %q, want %q", gotBody, wantBody)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("destination Content-Type = %q, want application/x-www-form-urlencoded", gotContentType)
+	}
+}
+
 func TestFetchHEADRefusesForbidden(t *testing.T) {
 	// A HEAD that draws a 403 must NOT fall back to a GET of the target: that
 	// GET can return the resource body (a 403 is intermittent / indistinguish-


### PR DESCRIPTION
## Summary
- `-X POST -d "..."` sends a form-urlencoded body through the fetch/redirect/challenge-retry chain (previously bodyless-only).
- Handles a second Tartarus challenge shape found live against a XenForo `/search/search` POST: `401` + `Www-Authenticate: Tartarus ... challenge_url="..."` + JSON body, instead of the classic `203`/HTML interstitial. Fetches the separate challenge_url for salt/difficulty and retries the *original* target (method+body) after clearance.
- `--cookie`/`--cookie-jar` persist cookies across invocations, since a form's CSRF token is bound to the session it was issued under (confirmed live: a token scraped from an unrelated page load gets rejected with XenForo's "Security error occurred").
- README documents the two-step session-then-POST flow.

## Test plan
- [x] `go test ./...` — all existing tests pass, plus new coverage: POST body survives the classic 203 challenge, POST body survives the new 401 API-style challenge (asserts the retry hits the original target, not the challenge endpoint), cookie save/load round trip.
- [x] `gofmt -l .` / `go vet ./...` clean
- [x] Verified live against a real XenForo onion service: two-step session bootstrap + POST to `/search/search` returns real results.